### PR TITLE
【Add】SSRでページロード時にAPIを走らせる機能を実装

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,6 @@
 import { Inter } from "next/font/google";
 import styles from "@/styles/Home.module.css";
-import { NextPage } from "next";
+import {  GetServerSideProps, NextPage } from "next";
 import { useState } from "react";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -10,18 +10,19 @@ const inter = Inter({ subsets: ["latin"] });
 //   status: string;
 // }
 
-// const random = Math.floor( Math.random() * 19 ) + 1;
-// console.log( random );
+interface IndexPageProps {
+  initialDogImageUrl: string;
+}
 
-const Home: NextPage = () => {
-  const [dogImageUrl, setDogImageUrl] = useState("");
+const fetchDogImage = async (): Promise<string> => {
+  const res = await fetch("https://dog.ceo/api/breed/shiba/images/random/1");
+  const result = await res.json();
+  return result.message[0];
+};
 
-  const fetchDogImage = async (): Promise<string> => {
-    const res = await fetch("https://dog.ceo/api/breed/shiba/images/random/1");
-    const result = await res.json();
-    return result.message[0];
-  };
-  
+const Home: NextPage<IndexPageProps> = ( {initialDogImageUrl} ) => {
+  const [dogImageUrl, setDogImageUrl] = useState(initialDogImageUrl);
+
   const handleClick = async () => {
     const dogImage = await fetchDogImage();
     setDogImageUrl(dogImage);
@@ -34,6 +35,16 @@ const Home: NextPage = () => {
       <button onClick={handleClick}>ワンワン !</button>
     </div>
   );
+};
+
+// Run API even when page loads with SSR
+export const getServerSideProps: GetServerSideProps<IndexPageProps> = async () => {
+  const dogImage = await fetchDogImage();
+  return {
+    props: {
+      initialDogImageUrl: dogImage,
+    },
+  };
 };
 
 export default Home;


### PR DESCRIPTION
- [x] SSRでページロード時にAPIを走らせる機能を実装
  - [x] `SSR`で`getServerSideProps`関数を実装
  - [x] `IndexPageProps`と命名した`interface`を実装
  - [x] `Homeコンポーネント`に`SSR`で取得した`initialCatImageUrl`を渡す実装
  - [x] `SSR`実装によって生じたエラーに対して`fetchDogImage`関数をページコンポーネントの外側に移動
  - [x] ここまでの開発ログ`development_log.md`を更新