### PR TITLE
【Add】indexページにリンクを設置し、Headerと名付けてコンポーネント化

### DIFF
--- a/components/Header.module.css
+++ b/components/Header.module.css
@@ -1,0 +1,20 @@
+.header {
+  border-bottom: 1px, sienna;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  
+}
+
+.header a {
+  display: inline-block;
+  color: brown;
+  padding: 5px 12px;
+  text-decoration: none;
+  transition: background-color .50s;
+}
+
+.header > a:hover {
+  background-color: lightblue;
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+import styles from "@/components/Header.module.css";
+
+const Header = () => {
+  return (
+    <header className={styles.header}>
+      <Link href="/">SHIBA</Link>
+      <Link href="/akita">AKITA</Link>
+    </header>
+  );
+}
+
+export { Header }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
 import { Inter } from "next/font/google";
 import styles from "@/styles/Home.module.css";
+import { Header } from "@/components/Header";
 import {  GetServerSideProps, NextPage } from "next";
 import { useCallback, useEffect, useState } from "react";
 
@@ -37,6 +38,7 @@ const Home: NextPage<IndexPageProps> = ( {initialDogImageUrl} ) => {
 
   return (
     <div className={styles.container}>
+      <Header />
       <h1>今日のSHIBA</h1>
       <img src={dogImageUrl} alt="shiba image" />
       <button onClick={handleClick}>ワンワン !</button>


### PR DESCRIPTION
- [x] indexページにリンクを設置し、Headerと名付けてコンポーネント化
  - [x] componentsディレクトリを生成
  - [x] Header.tsxを生成
  - [x] Header.module.cssを生成
  - [x] ヘッダーとして、SHIBA・AKITAページへ遷移するリンクを設置
  - [x] リンク群に対してスタイルを適用