### PR TITLE
【Fix】Googleフォントの呼び出しに不要な箇所を削除

### DIFF
--- a/pages/akita.tsx
+++ b/pages/akita.tsx
@@ -4,8 +4,6 @@ import { Header } from "@/components/Header";
 import {  GetServerSideProps, NextPage } from "next";
 import { useCallback, useEffect, useState } from "react";
 
-const inter = Inter({ subsets: ["latin"] });
-
 // interface SearchDogImage {
 //   message: string;
 //   status: string;

--- a/pages/shiba.tsx
+++ b/pages/shiba.tsx
@@ -4,8 +4,6 @@ import { Header } from "@/components/Header";
 import {  GetServerSideProps, NextPage } from "next";
 import { useCallback, useEffect, useState } from "react";
 
-const inter = Inter({ subsets: ["latin"] });
-
 // interface SearchDogImage {
 //   message: string;
 //   status: string;


### PR DESCRIPTION
- [x] Googleフォントの呼び出しに不要な箇所を削除
  - [x] `pages/shiba.tsx`の`const inter`文を削除
  - [x] `pages/akita.tsx`の`const inter`文を削除