### PR TITLE
【Add】Headlineコンポーネントを作成

### DIFF
--- a/components/Headline/Headline.module.css
+++ b/components/Headline/Headline.module.css
@@ -1,0 +1,3 @@
+.title h1 {
+  margin-bottom: 15px;
+}

--- a/components/Headline/index.tsx
+++ b/components/Headline/index.tsx
@@ -1,0 +1,17 @@
+import styles from "@/components/Headline/Headline.module.css";
+
+type Props = {
+  title: string
+}
+
+const Headline = (props: Props) => {
+  return (
+    <div>
+      <h1 className={styles.title}>
+        {props.title}
+      </h1>
+    </div>
+  );
+}
+
+export { Headline }

--- a/pages/akita.tsx
+++ b/pages/akita.tsx
@@ -1,5 +1,6 @@
 import styles from "@/styles/Akita.module.css";
 import { Header } from "@/components/Header";
+import { Headline } from "@/components/Headline";
 import {  GetServerSideProps, NextPage } from "next";
 import { useCallback, useEffect, useState } from "react";
 
@@ -31,7 +32,7 @@ const Akita: NextPage<IndexPageProps> = ( {initialDogImageUrl} ) => {
   return (
     <div className={styles.container}>
       <Header />
-      <h1>今日のAKITA</h1>
+      <Headline title="今日のAKITA" />
       <img src={dogImageUrl} alt="shiba image" />
       <button onClick={handleClick}>ワンワン !</button>
     </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,12 +1,13 @@
 import styles from "@/styles/Home.module.css";
 import { Header } from "@/components/Header";
+import { Headline } from "@/components/Headline";
 import Image from "next/image"
 
 const Home = () => {
   return (
     <div className={styles.container}>
       <Header />
-      <h1>今日のDOG</h1>
+      <Headline title="今日のDOG" />
       <Image
         src="/dog.png"
         alt="dog image"

--- a/pages/shiba.tsx
+++ b/pages/shiba.tsx
@@ -1,5 +1,6 @@
 import styles from "@/styles/Shiba.module.css";
 import { Header } from "@/components/Header";
+import { Headline } from "@/components/Headline";
 import {  GetServerSideProps, NextPage } from "next";
 import { useCallback, useEffect, useState } from "react";
 
@@ -31,7 +32,7 @@ const Shiba: NextPage<IndexPageProps> = ( {initialDogImageUrl} ) => {
   return (
     <div className={styles.container}>
       <Header />
-      <h1>今日のSHIBA</h1>
+      <Headline title="今日のSHIBA" />
       <img src={dogImageUrl} alt="shiba image" />
       <button onClick={handleClick}>ワンワン !</button>
     </div>


### PR DESCRIPTION
- [x] Headlineコンポーネントを作成
  - [x] `components`ディレクトリ配下に`Headline`ディレクトリおよび`cssファイル`と`index.tsxファイル`を作成
  - [x] `Headline/index.tsx`ファイルで`h1`タイトルのテキストをコンポーネント化
  - [x] `title`プロパティに対して`Props型`のメソッドでstringの型付けを実装
  - [x] 各種親コンポーネントにて`<Headline title~~/>`を呼び出す