### PR TITLE
【Add】APIで取得した画像をnext/imageに変更

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,17 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'images.dog.ceo',
+        port: '',
+        pathname: '/breeds/**',
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/pages/akita.tsx
+++ b/pages/akita.tsx
@@ -1,6 +1,7 @@
 import styles from "@/styles/Akita.module.css";
 import { Header } from "@/components/Header";
 import { Headline } from "@/components/Headline";
+import Image from "next/image"
 import {  GetServerSideProps, NextPage } from "next";
 import { useCallback, useEffect, useState } from "react";
 
@@ -33,7 +34,13 @@ const Akita: NextPage<IndexPageProps> = ( {initialDogImageUrl} ) => {
     <div className={styles.container}>
       <Header />
       <Headline title="今日のAKITA" />
-      <img src={dogImageUrl} alt="shiba image" />
+      <Image
+        src={dogImageUrl}
+        alt="akita image"
+        width={300}
+        height={300}
+        priority
+      />
       <button onClick={handleClick}>ワンワン !</button>
     </div>
   );

--- a/pages/shiba.tsx
+++ b/pages/shiba.tsx
@@ -1,6 +1,7 @@
 import styles from "@/styles/Shiba.module.css";
 import { Header } from "@/components/Header";
 import { Headline } from "@/components/Headline";
+import Image from "next/image"
 import {  GetServerSideProps, NextPage } from "next";
 import { useCallback, useEffect, useState } from "react";
 
@@ -33,7 +34,13 @@ const Shiba: NextPage<IndexPageProps> = ( {initialDogImageUrl} ) => {
     <div className={styles.container}>
       <Header />
       <Headline title="今日のSHIBA" />
-      <img src={dogImageUrl} alt="shiba image" />
+      <Image
+        src={dogImageUrl}
+        alt="shiba image"
+        width={300}
+        height={300}
+        priority
+      />
       <button onClick={handleClick}>ワンワン !</button>
     </div>
   );


### PR DESCRIPTION
- [x] APIで取得した画像をnext/imageに変更
  - [x] `next.config.mjs`にホストするdog_apiサイトの画像を指定
  - [x] `pages/akita.tsx`と`pages/shiba.tsx`に`<Image />`コンポーネントを実装